### PR TITLE
removing dependabot submission in non-deploy build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,3 @@ jobs:
     - name: Build with Maven
       run: mvn -B install -Dgpg.skip --file pom.xml
 
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
makes pull requests submitted without write access, including #53 to build.
Hopefully.
